### PR TITLE
feature/SCAN-131-see-all-with-search-params

### DIFF
--- a/src/components/SearchComponent.tsx
+++ b/src/components/SearchComponent.tsx
@@ -20,9 +20,6 @@ const SearchComponent: FC<SearchComponentProps> = ({ onSearchChange, placeholder
   const navigate = useNavigate();
 
   const onSearch = useCallback(() => {
-    if (!searchString) {
-      return;
-    }
 
     // user analytics
     const path = window.location.pathname;
@@ -38,7 +35,7 @@ const SearchComponent: FC<SearchComponentProps> = ({ onSearchChange, placeholder
     }
 
     // ethers address or substrate address
-    if ((/0x[0-9A-Fa-f]{40}/g).test(searchString) || (/^\w{48}\w*$/.test(searchString || ''))) {
+    if ((/0x[0-9A-Fa-f]{40}/g).test(searchString || '') || (/^\w{48}\w*$/.test(searchString || ''))) {
       navigate(`/${currentChain.network}/account/${searchString || ''}`);
 
       return;
@@ -50,7 +47,7 @@ const SearchComponent: FC<SearchComponentProps> = ({ onSearchChange, placeholder
       return;
     }
 
-    onSearchChange(searchString.trim());
+    onSearchChange(searchString ? searchString.trim() : searchString);
   }, [currentChain.network, navigate, onSearchChange, searchString]);
 
   const onSearchKeyDown = useCallback(

--- a/src/pages/Collections/components/CollectionsComponent.tsx
+++ b/src/pages/Collections/components/CollectionsComponent.tsx
@@ -11,13 +11,13 @@ import { useSearchParams } from 'react-router-dom';
 
 const CollectionsComponent = ({
   pageSize = 20,
-  orderBy: defaultOrderBy = { date_of_creation: 'desc' },
-  searchString
+  orderBy: defaultOrderBy = { date_of_creation: 'desc' }
 }: CollectionsComponentProps) => {
   const deviceSize = useDeviceSize();
   const { currentChain } = useApi();
 
   const [queryParams] = useSearchParams();
+  const searchString = queryParams.get('search') || '';
 
   const [orderBy, setOrderBy] = useState<CollectionSorting>(defaultOrderBy);
   const [currentPage, setCurrentPage] = useState<number>(1);

--- a/src/pages/Collections/index.tsx
+++ b/src/pages/Collections/index.tsx
@@ -1,23 +1,30 @@
-import React, { FC, useState } from 'react';
+import { FC } from 'react';
 import CollectionsComponent from './components/CollectionsComponent';
 import SearchComponent from '../../components/SearchComponent';
 import PagePaper from '../../components/PagePaper';
 import { useSearchParams } from 'react-router-dom';
 
 const CollectionsPage: FC = () => {
-  const [queryParams] = useSearchParams();
-  const searchParams = queryParams.get('search');
-  const [searchString, setSearchString] = useState<string | undefined>(searchParams || '');
+  const [queryParams, setQueryParams] = useSearchParams();
+
+
+  const onSearchChange = (value: string)=>{
+    if (!value) {
+      queryParams.delete('search');
+    } else {
+      queryParams.set('search', value);
+    }
+
+    setQueryParams(queryParams);
+  };
 
   return (<PagePaper>
     <SearchComponent
-      onSearchChange={setSearchString}
+      onSearchChange={onSearchChange}
       placeholder={'Сollection / account'}
     />
     <div>
-      <CollectionsComponent
-        searchString={searchString}
-      />
+      <CollectionsComponent />
     </div>
   </PagePaper>);
 };

--- a/src/pages/Collections/index.tsx
+++ b/src/pages/Collections/index.tsx
@@ -2,9 +2,12 @@ import React, { FC, useState } from 'react';
 import CollectionsComponent from './components/CollectionsComponent';
 import SearchComponent from '../../components/SearchComponent';
 import PagePaper from '../../components/PagePaper';
+import { useSearchParams } from 'react-router-dom';
 
 const CollectionsPage: FC = () => {
-  const [searchString, setSearchString] = useState<string | undefined>();
+  const [queryParams] = useSearchParams();
+  const searchParams = queryParams.get('search');
+  const [searchString, setSearchString] = useState<string | undefined>(searchParams || '');
 
   return (<PagePaper>
     <SearchComponent

--- a/src/pages/Collections/types.ts
+++ b/src/pages/Collections/types.ts
@@ -1,7 +1,6 @@
 import { CollectionSorting } from '../../api/graphQL/';
 
 export type CollectionsComponentProps = {
-  searchString?: string
   pageSize?: number
   orderBy?: CollectionSorting
 }

--- a/src/pages/Main/components/Collections/Collections.tsx
+++ b/src/pages/Main/components/Collections/Collections.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState, useMemo, VFC } from 'react';
 import styled from 'styled-components';
 import { useApi } from '@app/hooks';
-import { useNavigate } from 'react-router-dom';
+import { createSearchParams, useNavigate } from 'react-router-dom';
 import { Button, SelectOptionProps } from '@unique-nft/ui-kit';
 
 import { PagePaperWrapper } from '@app/components';
@@ -28,12 +28,20 @@ export const Collections: VFC<CollectionsProps> = ({ searchString }) => {
   const orderBy = useMemo((): CollectionSorting => selectedSort.id === 'new' ? { date_of_creation: 'desc' } : { actions_count: 'desc' }, [selectedSort.id]);
 
   const { collections, fetchMoreCollections, isCollectionsFetching, timestamp } = gqlCollections.useGraphQlCollections({ orderBy, pageSize });
-  const linkUrl = `/${currentChain.network}/collections`;
-
+ 
   const onClick = useCallback(() => {
+    const linkUrl = `/${currentChain.network}/collections`;
+    const navigateTo: {pathname: string, search?: string} = {pathname: linkUrl};
+
+    if(searchString){
+      const searchParams = `?${createSearchParams([['search', `${searchString}`]])}`;
+
+      navigateTo.search = searchParams;
+    }
+
     logUserEvents(UserEvents.Click.BUTTON_SEE_ALL_COLLECTIONS_ON_MAIN_PAGE);
-    navigate(linkUrl);
-  }, [linkUrl, navigate]);
+    navigate(navigateTo);
+  }, [ currentChain, navigate, searchString]);
 
   useEffect(() => {
     if (searchString === undefined) {

--- a/src/pages/Main/components/TokensBlock/Tokens.tsx
+++ b/src/pages/Main/components/TokensBlock/Tokens.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState, VFC } from 'react';
 import styled from 'styled-components';
 import { DeviceSize2, deviceWidth, useApi, useDeviceSize2 } from '@app/hooks';
-import { useNavigate } from 'react-router-dom';
+import { createSearchParams, useNavigate } from 'react-router-dom';
 import { Button, SelectOptionProps } from '@unique-nft/ui-kit';
 
 import { PagePaperWrapper, TokenCard } from '@app/components';
@@ -33,9 +33,18 @@ export const Tokens: VFC<TokensProps> = ({ collectionId, searchString }) => {
   }, [deviceSize]);
 
   const onClick = useCallback(() => {
+    const linkUrl = `/${currentChain.network}/tokens`;
+    const navigateTo: {pathname: string, search?: string} = {pathname: linkUrl};
+
+    if(searchString){
+      const searchParams = `?${createSearchParams([['search', `${searchString}`]])}`;
+
+      navigateTo.search = searchParams;
+    }
+
     logUserEvents(UserEvents.Click.BUTTON_SEE_ALL_NFTS_ON_MAIN_PAGE);
-    navigate(`/${currentChain.network}/tokens`);
-  }, [currentChain, navigate]);
+    navigate(navigateTo);
+  }, [currentChain, navigate, searchString]);
 
   const { isTokensFetching, timestamp, tokens } = gqlTokens.useGraphQlTokens({
     filter: collectionId ? { collection_id: { _eq: Number(collectionId) } } : undefined,

--- a/src/pages/Tokens/components/TokensComponent.tsx
+++ b/src/pages/Tokens/components/TokensComponent.tsx
@@ -2,7 +2,7 @@ import { Icon, Select } from '@unique-nft/ui-kit';
 import { SelectOptionProps } from '@unique-nft/ui-kit/dist/cjs/types';
 import { DefaultRecordType } from 'rc-table/lib/interface';
 import React, { FC, useCallback, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { Token, tokens as gqlTokens, TokenSorting } from '@app/api';
 import { Pagination, Search, Table } from '@app/components';
@@ -43,12 +43,13 @@ const TokensComponent: FC<TokensComponentProps> = ({
 }) => {
   const deviceSize = useDeviceSize();
   const { currentChain } = useApi();
-
+  const [queryParams] = useSearchParams();
+  const searchParams = queryParams.get('search');
   const { accountId, collectionId } = useParams();
 
   const [orderBy, setOrderBy] = useState<TokenSorting>(defaultOrderBy);
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [searchString, setSearchString] = useState<string | undefined>('');
+  const [searchString, setSearchString] = useState<string | undefined>(searchParams || '');
   const [selectOption, setSelectOption] = useState<SelectOptionProps>();
   const [view, setView] = useState<ViewType>(ViewType.Grid);
   const {

--- a/src/pages/Tokens/components/TokensComponent.tsx
+++ b/src/pages/Tokens/components/TokensComponent.tsx
@@ -43,13 +43,12 @@ const TokensComponent: FC<TokensComponentProps> = ({
 }) => {
   const deviceSize = useDeviceSize();
   const { currentChain } = useApi();
-  const [queryParams] = useSearchParams();
-  const searchParams = queryParams.get('search');
+  const [queryParams, setQueryParams] = useSearchParams();
+  const searchString = queryParams.get('search') || '';
   const { accountId, collectionId } = useParams();
 
   const [orderBy, setOrderBy] = useState<TokenSorting>(defaultOrderBy);
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [searchString, setSearchString] = useState<string | undefined>(searchParams || '');
   const [selectOption, setSelectOption] = useState<SelectOptionProps>();
   const [view, setView] = useState<ViewType>(ViewType.Grid);
   const {
@@ -98,6 +97,16 @@ const TokensComponent: FC<TokensComponentProps> = ({
     [setView]
   );
 
+  const onSearchChange = (value: string)=>{
+    if (!value) {
+      queryParams.delete('search');
+    } else {
+      queryParams.set('search', value);
+    }
+
+    setQueryParams(queryParams);
+  };
+
   const tokenColumns = useMemo(() => {
     return getTokensColumns(currentChain.network, orderBy, setOrderBy);
   }, [currentChain.network, orderBy]);
@@ -113,7 +122,7 @@ const TokensComponent: FC<TokensComponentProps> = ({
     <>
       <TopBar>
         <Search
-          onSearchChange={setSearchString}
+          onSearchChange={onSearchChange}
           placeholder={'NFT / collection'}
         />
         <Controls>


### PR DESCRIPTION
I save the value of the search in the navigation bar query parameters and later perform the initial rendering of the "tokens" and "collections" pages, taking into account these values.
I removed the stack to store the search string. Now this data is stored in the navigation query bar - only one source for search string